### PR TITLE
Replace deprecated builder

### DIFF
--- a/now.json
+++ b/now.json
@@ -8,7 +8,7 @@
   "builds": [
     {
       "src": "index.js",
-      "use": "@now/node-server",
+      "use": "@now/node",
       "config": {
         "includeFiles": [
           "binaries/**",


### PR DESCRIPTION
`@now/node-server` has been deprecated in favor of `@now/node`